### PR TITLE
Fix reading Groups token information when compiling for x86_64

### DIFF
--- a/src/information.rs
+++ b/src/information.rs
@@ -62,7 +62,7 @@ unsafe impl TokenInformation for Groups {
     unsafe fn from_buf(buf: &[u8]) -> Option<Self::Output> {
         let count = u32::from_ne_bytes(buf[0..4].try_into().unwrap());
 
-        let arr_start = buf[4..].as_ptr() as *const SID_AND_ATTRIBUTES;
+        let arr_start = buf[std::mem::align_of::<*const SID_AND_ATTRIBUTES>()..].as_ptr() as *const SID_AND_ATTRIBUTES;
         let mut output = Vec::new();
         for i in 0..count {
             let sid_attr = *arr_start.offset(i as isize);


### PR DESCRIPTION
The struct we're reading from the buffer is defined as such:

```
typedef struct _TOKEN_GROUPS {
  DWORD              GroupCount;
  SID_AND_ATTRIBUTES *Groups[];
} TOKEN_GROUPS, *PTOKEN_GROUPS;
```

which would translate to this in rust:

```
pub struct _TOKEN_GROUPS {
    pub GroupCount: u32,
    Groups: *const c_void,
}
```

The previous code used to assume that the offset of `Groups` was 4,
which is true on i686 but not on x86_64.

Output of `rustc -Zprint-type-sizes` on i686
```
print-type-size type: `_TOKEN_GROUPS`: 8 bytes, alignment: 4 bytes
print-type-size     field `.GroupCount`: 4 bytes
print-type-size     field `.Groups`: 4 bytes
```

Output of `rustc -Zprint-type-sizes` on x86_64
```
print-type-size type: `_TOKEN_GROUPS`: 16 bytes, alignment: 8 bytes
print-type-size     field `.GroupCount`: 4 bytes
print-type-size     padding: 4 bytes
print-type-size     field `.Groups`: 8 bytes, alignment: 8 bytes
```